### PR TITLE
Add Docker pull for OpenJDK 21

### DIFF
--- a/WatchWolfSetup.sh
+++ b/WatchWolfSetup.sh
@@ -73,6 +73,7 @@ case "$opt" in
 		sudo docker pull openjdk:8
 		sudo docker pull openjdk:16
 		sudo docker pull openjdk:17
+		sudo docker pull openjdk:21
 
 		if [ $no_spigot -eq 0 ]; then
 			dos2unix "$server_builders_path/SpigotBuilder.sh" "$server_builders_path/PaperBuilder.sh"


### PR DESCRIPTION
Since https://github.com/watch-wolf/WatchWolf-Core/commit/dff9e088a3e0636b5fa1c453d5e0188c67d4f319 OpenJDK 21 is also needed